### PR TITLE
feat: add Credential Issuance test cases (CS)

### DIFF
--- a/config/tck/sample.tck.properties
+++ b/config/tck/sample.tck.properties
@@ -1,1 +1,4 @@
 # Contains sample configuration options
+dataspacetck.test.package=org.eclipse.dataspacetck.dcp.verification.presentation
+#dataspacetck.test.package=org.eclipse.dataspacetck.dcp.verification.issuance.cs
+dataspacetck.credentials.correlation.id=foobar

--- a/dcp-api/src/main/java/org/eclipse/dataspacetck/dcp/system/annotation/Credential.java
+++ b/dcp-api/src/main/java/org/eclipse/dataspacetck/dcp/system/annotation/Credential.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspacetck.dcp.system.annotation;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation used to inject randomly generated credentials of the given type into a test method
+ */
+@Inherited
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER})
+public @interface Credential {
+    String value();
+}

--- a/dcp-api/src/main/java/org/eclipse/dataspacetck/dcp/system/annotation/HolderPid.java
+++ b/dcp-api/src/main/java/org/eclipse/dataspacetck/dcp/system/annotation/HolderPid.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspacetck.dcp.system.annotation;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Holder-assigned Process Identifier (PID) when dealing with Credential Issuance messages
+ */
+@Inherited
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER})
+public @interface HolderPid {
+}

--- a/dcp-api/src/main/java/org/eclipse/dataspacetck/dcp/system/annotation/Issuer.java
+++ b/dcp-api/src/main/java/org/eclipse/dataspacetck/dcp/system/annotation/Issuer.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspacetck.dcp.system.annotation;
+
+import org.eclipse.dataspacetck.core.api.system.Inject;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * For field injection, used in conjunction with {@link Inject} to specify the injection of a verifier service.
+ */
+@Inherited
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER})
+public @interface Issuer {
+}

--- a/dcp-api/src/main/java/org/eclipse/dataspacetck/dcp/system/cs/CredentialService.java
+++ b/dcp-api/src/main/java/org/eclipse/dataspacetck/dcp/system/cs/CredentialService.java
@@ -14,10 +14,9 @@
 
 package org.eclipse.dataspacetck.dcp.system.cs;
 
-import org.eclipse.dataspacetck.dcp.system.model.vc.VcContainer;
 import org.eclipse.dataspacetck.dcp.system.service.Result;
 
-import java.util.List;
+import java.io.InputStream;
 import java.util.Map;
 
 /**
@@ -33,5 +32,5 @@ public interface CredentialService {
     /**
      * Writes issued credentials.
      */
-    Result<Void> writeCredentials(String bearerDid, String correlationId, List<VcContainer> containers);
+    Result<Void> writeCredentials(String idTokenJwt, InputStream body);
 }

--- a/dcp-api/src/main/java/org/eclipse/dataspacetck/dcp/system/message/DcpConstants.java
+++ b/dcp-api/src/main/java/org/eclipse/dataspacetck/dcp/system/message/DcpConstants.java
@@ -57,6 +57,8 @@ public interface DcpConstants {
 
     String PRESENTATION_QUERY_PATH = "/presentations/query";
 
+    String CREDENTIALS_PATH = "/credentials";
+
     String CREDENTIAL_OFFER_MESSAGE_TYPE = "CredentialOfferMessage";
 
     String CREDENTIAL_MESSAGE_TYPE = "CredentialMessage";

--- a/dcp-api/src/main/java/org/eclipse/dataspacetck/dcp/system/service/Result.java
+++ b/dcp-api/src/main/java/org/eclipse/dataspacetck/dcp/system/service/Result.java
@@ -18,13 +18,15 @@ package org.eclipse.dataspacetck.dcp.system.service;
  * Result of a service invocation.
  */
 public class Result<T> {
-    public enum ErrorType {
-        NOT_FOUND, UNAUTHORIZED, BAD_REQUEST, GENERAL_ERROR, NO_ERROR
-    }
-
     private final T content;
     private final String failure;
     private final ErrorType errorType;
+
+    private Result(T content, String failure, ErrorType errorType) {
+        this.content = content;
+        this.failure = failure;
+        this.errorType = errorType;
+    }
 
     public static Result<Void> success() {
         return new Result<>(null, null, ErrorType.NO_ERROR);
@@ -32,6 +34,14 @@ public class Result<T> {
 
     public static <T> Result<T> success(T content) {
         return new Result<>(content, null, ErrorType.NO_ERROR);
+    }
+
+    public static <T> Result<T> failure(String failure) {
+        return new Result<>(null, failure, ErrorType.GENERAL_ERROR);
+    }
+
+    public static <T> Result<T> failure(String failure, ErrorType errorType) {
+        return new Result<>(null, failure, errorType);
     }
 
     public boolean succeeded() {
@@ -54,22 +64,12 @@ public class Result<T> {
         return errorType;
     }
 
-    public static <T> Result<T> failure(String failure) {
-        return new Result<>(null, failure, ErrorType.GENERAL_ERROR);
-    }
-
-    public static <T> Result<T> failure(String failure, ErrorType errorType) {
-        return new Result<>(null, failure, errorType);
-    }
-
     public <R> R convert() {
         //noinspection unchecked
         return (R) this;
     }
 
-    private Result(T content, String failure, ErrorType errorType) {
-        this.content = content;
-        this.failure = failure;
-        this.errorType = errorType;
+    public enum ErrorType {
+        NOT_FOUND, UNAUTHORIZED, BAD_REQUEST, GENERAL_ERROR, NO_ERROR
     }
 }

--- a/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/DcpSystemLauncher.java
+++ b/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/DcpSystemLauncher.java
@@ -132,7 +132,7 @@ public class DcpSystemLauncher implements SystemLauncher {
     @Override
     public void beforeExecution(ServiceConfiguration configuration, ServiceResolver resolver) {
         if (hasAnnotation(IssueCredentials.class, configuration)) {
-            serviceAssemblies.get(configuration.getScopeId()).issueCredentials(baseAssembly, configuration);
+            serviceAssemblies.get(configuration.getScopeId()).issueCredentials(baseAssembly);
         }
     }
 

--- a/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/assembly/BaseAssembly.java
+++ b/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/assembly/BaseAssembly.java
@@ -28,6 +28,8 @@ import java.net.URI;
 import java.util.Objects;
 
 import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
+import static java.util.UUID.randomUUID;
 import static org.eclipse.dataspacetck.core.api.system.SystemsConstants.TCK_CALLBACK_ADDRESS;
 import static org.eclipse.dataspacetck.core.api.system.SystemsConstants.TCK_DEFAULT_CALLBACK_ADDRESS;
 import static org.eclipse.dataspacetck.core.api.system.SystemsConstants.TCK_PREFIX;
@@ -52,6 +54,7 @@ public class BaseAssembly {
     private final KeyServiceImpl thirdPartyKeyService;
     private final DidServiceImpl thirdPartyDidService;
     private final ObjectMapper mapper;
+    private final String holderPid;
 
     public BaseAssembly(SystemConfiguration configuration) {
         mapper = new ObjectMapper();
@@ -67,6 +70,8 @@ public class BaseAssembly {
         holderKeyService = new KeyServiceImpl(Keys.generateEcKey());
         holderDidService = new DidServiceImpl(holderDid, address, holderKeyService);
         holderTokenService = new TokenValidationServiceImpl(holderDid);
+
+        holderPid = ofNullable(configuration.getPropertyAsString(TCK_PREFIX + "credentials.correlation.id", null)).orElseGet(() -> randomUUID().toString());
 
         verifierTokenService = new TokenValidationServiceImpl(verifierDid);
         verifierKeyService = new KeyServiceImpl(Keys.generateEcKey());
@@ -145,4 +150,9 @@ public class BaseAssembly {
         return uri.getPort() != 443 ? format("did:web:%s%%3A%s:%s", uri.getHost(), uri.getPort(), discriminator)
                 : format("did:web:%s:%s", uri.getHost(), discriminator);
     }
+
+    public String getHolderPid() {
+        return holderPid;
+    }
+
 }

--- a/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/assembly/BaseAssembly.java
+++ b/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/assembly/BaseAssembly.java
@@ -71,7 +71,7 @@ public class BaseAssembly {
         holderDidService = new DidServiceImpl(holderDid, address, holderKeyService);
         holderTokenService = new TokenValidationServiceImpl(holderDid);
 
-        holderPid = ofNullable(configuration.getPropertyAsString(TCK_PREFIX + "credentials.correlation.id", null)).orElseGet(() -> randomUUID().toString());
+        holderPid = ofNullable(configuration.getPropertyAsString(TCK_PREFIX + ".credentials.correlation.id", null)).orElseGet(() -> randomUUID().toString());
 
         verifierTokenService = new TokenValidationServiceImpl(verifierDid);
         verifierKeyService = new KeyServiceImpl(Keys.generateEcKey());

--- a/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/assembly/ServiceAssembly.java
+++ b/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/assembly/ServiceAssembly.java
@@ -46,7 +46,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 
 import static java.time.Instant.now;
@@ -99,7 +98,7 @@ public class ServiceAssembly {
         return secureTokenServer;
     }
 
-    public void issueCredentials(BaseAssembly baseAssembly, ServiceConfiguration config) {
+    public void issueCredentials(BaseAssembly baseAssembly) {
         var issuerDid = baseAssembly.getIssuerDid();
         var credentialGenerator = new JwtCredentialGenerator(issuerDid, baseAssembly.getIssuerKeyService());
 
@@ -108,7 +107,7 @@ public class ServiceAssembly {
         var membershipContainer = createVcContainer(issuerDid, holderDid, credentialGenerator, MEMBERSHIP_CREDENTIAL_TYPE);
         var sensitiveDataContainer = createVcContainer(issuerDid, holderDid, credentialGenerator, SENSITIVE_DATA_CREDENTIAL_TYPE);
 
-        var correlation = Optional.ofNullable(config.getPropertyAsString("dataspacetck.credentials.correlation.id", null)).orElseGet(() -> randomUUID().toString());
+        var correlation = baseAssembly.getHolderPid();
 
         var claimSet = new JWTClaimsSet.Builder()
                 .issuer(issuerDid)

--- a/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/assembly/ServiceAssembly.java
+++ b/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/assembly/ServiceAssembly.java
@@ -66,6 +66,7 @@ public class ServiceAssembly {
     private final SecureTokenServer secureTokenServer;
 
     public ServiceAssembly(BaseAssembly baseAssembly, ServiceResolver resolver, ServiceConfiguration configuration) {
+        var tokenService = baseAssembly.getHolderTokenService();
         var generator = new JwtPresentationGenerator(baseAssembly.getHolderDid(), baseAssembly.getHolderKeyService());
         var mapper = baseAssembly.getMapper();
 
@@ -76,11 +77,11 @@ public class ServiceAssembly {
         var monitor = configuration.getMonitor();
 
         // register the handlers
-        var tokenService = baseAssembly.getHolderTokenService();
+        // ... for presentation query
         var presentationHandler = new PresentationHandler(credentialService, tokenService, mapper, monitor);
         endpoint.registerProtocolHandler("/presentations/query", presentationHandler);
 
-        // default handler for credential issuance
+        // ... for credential issuance
         endpoint.registerProtocolHandler("/credentials", new CredentialIssuanceHandler(credentialService));
 
         endpoint.registerHandler("/holder/did.json", new DidDocumentHandler(baseAssembly.getHolderDidService(), mapper));
@@ -144,7 +145,8 @@ public class ServiceAssembly {
                                 "credentialType", SENSITIVE_DATA_CREDENTIAL_TYPE,
                                 "format", "VC1_0_JWT",
                                 "payload", sensitiveDataContainer.rawCredential()
-                        )));
+                        )))
+                .property("status", "ISSUED");
 
         var msg = baseAssembly.getMapper().writeValueAsString(credentialsObject.build());
         sendCredentialServiceMessage(msg, "/credentials", token, baseAssembly.getHolderDid());

--- a/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/cs/CredentialIssuanceHandler.java
+++ b/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/cs/CredentialIssuanceHandler.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspacetck.dcp.system.cs;
+
+import org.eclipse.dataspacetck.core.api.system.HandlerResponse;
+import org.eclipse.dataspacetck.core.api.system.ProtocolHandler;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+public class CredentialIssuanceHandler implements ProtocolHandler {
+    private final CredentialService credentialService;
+
+    public CredentialIssuanceHandler(CredentialService credentialService) {
+        this.credentialService = credentialService;
+    }
+
+    @Override
+    public HandlerResponse apply(Map<String, List<String>> headers, InputStream body) {
+        var authHeaders = headers.get("Authorization");
+        if (authHeaders == null || authHeaders.isEmpty() || authHeaders.get(0).isEmpty() || !authHeaders.get(0).startsWith("Bearer ")) {
+            return new HandlerResponse(401, "Missing access token");
+        }
+
+        var idToken = headers.get("Authorization").get(0);
+        idToken = idToken.replace("Bearer", "").trim();
+
+        var result = credentialService.writeCredentials(idToken, body);
+
+        if (result.succeeded()) {
+            return new HandlerResponse(200, "");
+        }
+        return switch (result.getErrorType()) {
+            case BAD_REQUEST -> new HandlerResponse(400, result.getFailure());
+            case UNAUTHORIZED -> new HandlerResponse(401, result.getFailure());
+            case NOT_FOUND -> new HandlerResponse(404, result.getFailure());
+            default -> new HandlerResponse(500, result.getFailure());
+        };
+
+    }
+}

--- a/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/cs/CredentialMessage.java
+++ b/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/cs/CredentialMessage.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspacetck.dcp.system.cs;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CredentialMessage {
+    @JsonProperty(value = "credentials", required = true)
+    private final List<CredentialContainer> credentials = new ArrayList<>();
+    @JsonProperty(value = "issuerPid", required = true)
+    private String issuerPid;
+    @JsonProperty(value = "holderPid", required = true)
+    private String holderPid;
+    @JsonProperty(value = "status", required = true)
+    private String status;
+    @JsonProperty(value = "type", required = true, defaultValue = "ISSUED")
+    private String type;
+
+
+    public boolean validate() {
+        return List.of("ISSUED", "REJECTED").contains(status) &&
+                issuerPid != null &&
+                holderPid != null &&
+                !credentials.isEmpty();
+    }
+
+    public List<CredentialContainer> getCredentials() {
+        return credentials;
+    }
+
+    public String getIssuerPid() {
+        return issuerPid;
+    }
+
+    public String getHolderPid() {
+        return holderPid;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public record CredentialContainer(String credentialType, String payload, String format) {
+    }
+}

--- a/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/cs/TokenValidationServiceImpl.java
+++ b/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/cs/TokenValidationServiceImpl.java
@@ -80,6 +80,10 @@ public class TokenValidationServiceImpl implements TokenValidationService {
                 return failure("IAT not specified");
             }
 
+            if (claims.getIssueTime().after(new Date())) {
+                return failure("Token issued in the future");
+            }
+
             if (claims.getNotBeforeTime() != null && claims.getNotBeforeTime().after(new Date())) {
                 return failure("Token used before start");
             }

--- a/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/sts/SecureTokenServer.java
+++ b/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/sts/SecureTokenServer.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.dataspacetck.dcp.system.sts;
 
+import org.eclipse.dataspacetck.dcp.system.crypto.KeyService;
+import org.eclipse.dataspacetck.dcp.system.cs.TokenValidationService;
 import org.eclipse.dataspacetck.dcp.system.service.Result;
 
 import java.util.List;
@@ -31,11 +33,11 @@ public interface SecureTokenServer extends StsClient {
     /**
      * Authorize a write operation with scopes for the given bearer and correlation id.
      */
-    void authorizeWrite(String bearerDid, String correlationId, List<String> scopes);
+    String authorizeWrite(KeyService keyService, String bearerDid, String correlationId, String audience);
 
     /**
      * Validates a write operation.
      */
-    Result<List<String>> validateWrite(String bearerDid, String correlationId);
+    Result<Void> validateWrite(String serializedJwt, TokenValidationService holderTokenService);
 
 }

--- a/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/sts/StsClient.java
+++ b/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/sts/StsClient.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.dataspacetck.dcp.system.sts;
 
+import org.eclipse.dataspacetck.dcp.system.crypto.KeyService;
 import org.eclipse.dataspacetck.dcp.system.service.Result;
 
 import java.util.List;
@@ -27,8 +28,9 @@ public interface StsClient {
      * Obtains the token
      *
      * @param bearerDid the bearer's DID to bind the token
-     * @param scopes      requested scope
+     * @param scopes    requested scope
      */
     Result<String> obtainReadToken(String bearerDid, List<String> scopes);
 
+    Result<String> obtainWriteToken(String bearerDid, String audience, KeyService keyService);
 }

--- a/dcp-system/src/test/java/org/eclipse/dataspacetck/dcp/system/generation/JwtPresentationGeneratorTest.java
+++ b/dcp-system/src/test/java/org/eclipse/dataspacetck/dcp/system/generation/JwtPresentationGeneratorTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
+import static org.assertj.core.api.InstanceOfAssertFactories.MAP;
 import static org.eclipse.dataspacetck.dcp.system.crypto.Keys.createVerifier;
 import static org.eclipse.dataspacetck.dcp.system.model.vc.CredentialFormat.VC1_0_JWT;
 
@@ -36,9 +37,23 @@ class JwtPresentationGeneratorTest {
     private static final String ISSUER_DID = "did:web:localhost%3A8083:issuer";
     private static final String HOLDER_DID = "did:web:localhost%3A8083:holder";
     private static final String VERIFIER_DID = "did:web:localhost%3A8083:verifier";
-
+    private static final String SAMPLE_VC = """
+            eyJraWQiOiJkaWQ6d2ViOmxvY2FsaG9zdCUzQTgwODM6aXNzdWVyIzg0ZmE4YmVmLTc2NmQtNDMxYy04OWVlLTgxM2QyN2RjY2VjMyIsInR5
+            cCI6IkpXVCIsImFsZyI6IkVTMjU2In0.eyJzdWIiOiIzYmU1NDAxMi0zNTEzLTRhZjQtYTBmMy00ZWJmNzA1ZDE5NDEiLCJuYmYiOjE3Mzkx
+            OTgwMDcsImlzcyI6ImRpZDp3ZWI6bG9jYWxob3N0JTNBODA4Mzppc3N1ZXIiLCJleHAiOjE3MzkxOTgzMDcsImlhdCI6MTczOTE5ODAwNywi
+            dmMiOnsiQGNvbnRleHQiOiIzYmU1NDAxMi0zNTEzLTRhZjQtYTBmMy00ZWJmNzA1ZDE5NDEiLCJpZCI6IjNiZTU0MDEyLTM1MTMtNGFmNC1h
+            MGYzLTRlYmY3MDVkMTk0MSIsInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiZGlkOndlYjpsb2NhbGhvc3QlM0E4
+            MDgzOmlzc3VlciIsImlzc3VhbmNlRGF0ZSI6Ik1vbiBGZWIgMTAgMTU6MzM6MjcgQ0VUIDIwMjUiLCJjcmVkZW50aWFsU3ViamVjdCI6eyJt
+            ZW1iZXJMZXZlbCI6ImdvbGQifX0sImp0aSI6ImFmOGI1NzMxLWJkYjQtNGMzZS05ZjIzLWM2MzJjMmViZjI0OCJ9.00q5xQtulyFvTBmTFs6
+            Uh7xb-PqDsxd6TKzvO7n0AE9uhYQGbap9634vm7AvMnfWcTqaRV02HZbHCyJ21aFkHg""";
     private JwtPresentationGenerator generator;
     private KeyServiceImpl keyService;
+
+    @BeforeEach
+    void setUp() {
+        keyService = new KeyServiceImpl(Keys.generateEcKey());
+        generator = new JwtPresentationGenerator(ISSUER_DID, keyService);
+    }
 
     @Test
     void verifyGeneration() throws ParseException, JOSEException {
@@ -49,24 +64,13 @@ class JwtPresentationGeneratorTest {
         var claims = parsed.getJWTClaimsSet().getClaims();
 
         assertThat(parsed.getHeader().getKeyID()).isEqualTo(ISSUER_DID + "#" + keyService.getPublicKey().getKeyID());
-        assertThat(claims.get("vc")).asInstanceOf(LIST).first().isEqualTo(SAMPLE_VC);
+
+        assertThat(claims.get("vp")).asInstanceOf(MAP).hasEntrySatisfying("verifiableCredential", credentialJwts -> {
+            assertThat(credentialJwts).asInstanceOf(LIST).hasSize(1);
+            assertThat(credentialJwts).asInstanceOf(LIST).first().isEqualTo(SAMPLE_VC);
+        });
+
         var verifier = createVerifier(keyService.getPublicKey().toECKey().toECPublicKey());
         assertThat(parsed.verify(verifier)).isTrue();
     }
-
-    @BeforeEach
-    void setUp() {
-        keyService = new KeyServiceImpl(Keys.generateEcKey());
-        generator = new JwtPresentationGenerator(ISSUER_DID, keyService);
-    }
-
-    private static final String SAMPLE_VC = """
-            eyJraWQiOiJkaWQ6d2ViOmxvY2FsaG9zdCUzQTgwODM6aXNzdWVyIzg0ZmE4YmVmLTc2NmQtNDMxYy04OWVlLTgxM2QyN2RjY2VjMyIsInR5
-            cCI6IkpXVCIsImFsZyI6IkVTMjU2In0.eyJzdWIiOiIzYmU1NDAxMi0zNTEzLTRhZjQtYTBmMy00ZWJmNzA1ZDE5NDEiLCJuYmYiOjE3Mzkx
-            OTgwMDcsImlzcyI6ImRpZDp3ZWI6bG9jYWxob3N0JTNBODA4Mzppc3N1ZXIiLCJleHAiOjE3MzkxOTgzMDcsImlhdCI6MTczOTE5ODAwNywi
-            dmMiOnsiQGNvbnRleHQiOiIzYmU1NDAxMi0zNTEzLTRhZjQtYTBmMy00ZWJmNzA1ZDE5NDEiLCJpZCI6IjNiZTU0MDEyLTM1MTMtNGFmNC1h
-            MGYzLTRlYmY3MDVkMTk0MSIsInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiZGlkOndlYjpsb2NhbGhvc3QlM0E4
-            MDgzOmlzc3VlciIsImlzc3VhbmNlRGF0ZSI6Ik1vbiBGZWIgMTAgMTU6MzM6MjcgQ0VUIDIwMjUiLCJjcmVkZW50aWFsU3ViamVjdCI6eyJt
-            ZW1iZXJMZXZlbCI6ImdvbGQifX0sImp0aSI6ImFmOGI1NzMxLWJkYjQtNGMzZS05ZjIzLWM2MzJjMmViZjI0OCJ9.00q5xQtulyFvTBmTFs6
-            Uh7xb-PqDsxd6TKzvO7n0AE9uhYQGbap9634vm7AvMnfWcTqaRV02HZbHCyJ21aFkHg""";
 }

--- a/dcp-tck/src/main/java/org/eclipse/dataspacetck/dcp/suite/DcpTckSuite.java
+++ b/dcp-tck/src/main/java/org/eclipse/dataspacetck/dcp/suite/DcpTckSuite.java
@@ -50,14 +50,14 @@ public class DcpTckSuite {
         if (!properties.containsKey(TCK_LAUNCHER)) {
             properties.put(TCK_LAUNCHER, DEFAULT_LAUNCHER);
         }
-        if (properties.containsKey(TCK_TEST_PACKAGE)) {
+        if (!properties.containsKey(TCK_TEST_PACKAGE)) {
             properties.put(TCK_TEST_PACKAGE, DEFAULT_TEST_PACKAGE);
         }
         var monitor = createMonitor(properties);
         monitor.enableBold().message("\u001B[1mRunning DCP TCK v" + VERSION + "\u001B[0m").resetMode();
         var result = TckRuntime.Builder.newInstance()
                 .properties(properties)
-                .addPackage(DEFAULT_TEST_PACKAGE)
+                .addPackage(properties.get(TCK_TEST_PACKAGE))
                 .monitor(monitor)
                 .build().execute();
 

--- a/dcp-tck/src/main/java/org/eclipse/dataspacetck/dcp/suite/DcpTckSuite.java
+++ b/dcp-tck/src/main/java/org/eclipse/dataspacetck/dcp/suite/DcpTckSuite.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.lang.Boolean.parseBoolean;
 import static java.util.stream.Collectors.toMap;
@@ -50,15 +51,17 @@ public class DcpTckSuite {
         if (!properties.containsKey(TCK_LAUNCHER)) {
             properties.put(TCK_LAUNCHER, DEFAULT_LAUNCHER);
         }
-        if (!properties.containsKey(TCK_TEST_PACKAGE)) {
-            properties.put(TCK_TEST_PACKAGE, DEFAULT_TEST_PACKAGE);
-        }
         var monitor = createMonitor(properties);
         monitor.enableBold().message("\u001B[1mRunning DCP TCK v" + VERSION + "\u001B[0m").resetMode();
-        var result = TckRuntime.Builder.newInstance()
+
+        var packages = properties.getOrDefault(TCK_TEST_PACKAGE, DEFAULT_TEST_PACKAGE).split(",");
+
+        var runtimeBuilder = TckRuntime.Builder.newInstance()
                 .properties(properties)
-                .addPackage(properties.get(TCK_TEST_PACKAGE))
-                .monitor(monitor)
+                .monitor(monitor);
+
+        Stream.of(packages).forEach(runtimeBuilder::addPackage);
+        var result = runtimeBuilder
                 .build().execute();
 
 

--- a/dcp-testcases/src/main/java/org/eclipse/dataspacetck/dcp/verification/issuance/cs/CredentialIssuanceTest.java
+++ b/dcp-testcases/src/main/java/org/eclipse/dataspacetck/dcp/verification/issuance/cs/CredentialIssuanceTest.java
@@ -1,0 +1,278 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspacetck.dcp.verification.issuance.cs;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jwt.JWTClaimsSet;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import org.eclipse.dataspacetck.api.system.MandatoryTest;
+import org.eclipse.dataspacetck.core.api.system.Inject;
+import org.eclipse.dataspacetck.core.system.SystemBootstrapExtension;
+import org.eclipse.dataspacetck.dcp.system.annotation.Credential;
+import org.eclipse.dataspacetck.dcp.system.annotation.Did;
+import org.eclipse.dataspacetck.dcp.system.annotation.HolderPid;
+import org.eclipse.dataspacetck.dcp.system.annotation.IssuanceFlow;
+import org.eclipse.dataspacetck.dcp.system.annotation.Issuer;
+import org.eclipse.dataspacetck.dcp.system.crypto.KeyService;
+import org.eclipse.dataspacetck.dcp.system.did.DidClient;
+import org.eclipse.dataspacetck.dcp.system.message.DcpMessageBuilder;
+import org.eclipse.dataspacetck.dcp.system.model.vc.VcContainer;
+import org.eclipse.dataspacetck.dcp.verification.fixtures.TestFixtures;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static java.time.Instant.now;
+import static java.util.Collections.emptyMap;
+import static java.util.UUID.randomUUID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dataspacetck.dcp.system.annotation.RoleType.HOLDER;
+import static org.eclipse.dataspacetck.dcp.system.annotation.RoleType.ISSUER;
+import static org.eclipse.dataspacetck.dcp.system.annotation.RoleType.THIRD_PARTY;
+import static org.eclipse.dataspacetck.dcp.system.message.DcpConstants.AUTHORIZATION;
+import static org.eclipse.dataspacetck.dcp.system.message.DcpConstants.CREDENTIALS_PATH;
+import static org.eclipse.dataspacetck.dcp.system.message.DcpConstants.CREDENTIAL_MESSAGE_TYPE;
+import static org.eclipse.dataspacetck.dcp.system.message.DcpConstants.CREDENTIAL_SERVICE_TYPE;
+import static org.eclipse.dataspacetck.dcp.system.profile.TestProfile.MEMBERSHIP_CREDENTIAL_TYPE;
+import static org.eclipse.dataspacetck.dcp.system.profile.TestProfile.SENSITIVE_DATA_CREDENTIAL_TYPE;
+import static org.eclipse.dataspacetck.dcp.verification.fixtures.TestFixtures.executeRequest;
+
+/**
+ * Verifies Credential Issuance messages testing the CredentialService as system-under-test.
+ */
+@IssuanceFlow
+@ExtendWith(SystemBootstrapExtension.class)
+public class CredentialIssuanceTest {
+    private final ObjectMapper mapper = new ObjectMapper();
+    @Inject
+    @Did(ISSUER)
+    protected String issuerDid;
+
+    @Inject
+    @Did(HOLDER)
+    protected String holderDid;
+
+    @Inject
+    @Credential(MEMBERSHIP_CREDENTIAL_TYPE)
+    private VcContainer membershipCredential;
+
+    @Inject
+    @Credential(SENSITIVE_DATA_CREDENTIAL_TYPE)
+    private VcContainer sensitiveDataCredential;
+
+    @Inject
+    @Issuer
+    private KeyService issuerKeyService;
+
+    @MandatoryTest
+    @DisplayName("6.5.1 CredentialService should accept expected CredentialMessage")
+    void cs_06_05_01_credentialMessage(@HolderPid String holderPid) {
+
+        var credentialMessage = createCredentialMessage(holderPid)
+                .build();
+
+        var token = createToken(createClaims().build());
+        var request = createCredentialMessageRequest(token, credentialMessage).build();
+        executeRequest(request, response -> assertThat(response.code()).isEqualTo(200));
+    }
+
+
+    @MandatoryTest
+    @DisplayName("6.5.1 CredentialService rejects a CredentialMessage with no auth header")
+    void cs_06_05_01_credentialMessage_noAuthHeader(@HolderPid String holderPid) {
+        var credentialMessage = createCredentialMessage(holderPid).build();
+
+        var request = createCredentialMessageRequest(null, credentialMessage).build();
+        executeRequest(request, TestFixtures::assert4xxxCode);
+    }
+
+    @MandatoryTest
+    @DisplayName("6.5.1 CredentialService rejects a CredentialMessage where the auth header has no bearer prefix")
+    void cs_06_05_01_credentialMessage_missingBearerPrefix(@HolderPid String holderPid) {
+        var credentialMessage = createCredentialMessage(holderPid).build();
+        var token = createToken(createClaims().build());
+
+        var request = createCredentialMessageRequest(null, credentialMessage)
+                .header("Authorization", token)
+                .build();
+        executeRequest(request, TestFixtures::assert4xxxCode);
+    }
+
+    @MandatoryTest
+    @DisplayName("6.5.1 CredentialService rejects a CredentialMessage with an invalid message body")
+    void cs_06_05_01_credentialMessage_invalidBody(@HolderPid String holderPid) {
+        var credentialMessage = createCredentialMessage(holderPid).build();
+
+        var invalidMessage = new HashMap<>(credentialMessage);
+        invalidMessage.remove("holderPid");
+        var token = createToken(createClaims().build());
+
+        var request = createCredentialMessageRequest(token, invalidMessage).build();
+        executeRequest(request, TestFixtures::assert4xxxCode);
+    }
+
+    @MandatoryTest
+    @DisplayName("6.5.1 CredentialService rejects an invalid auth token - wrong signing key")
+    void cs_06_05_01_credentialMessage_tokenSignedWithWrongKey() {
+
+    }
+
+    @MandatoryTest
+    @DisplayName("6.5.1 CredentialService rejects an invalid auth token - token expired")
+    void cs_06_05_01_credentialMessage_tokenExpired(@HolderPid String holderPid) {
+        var credentialMessage = createCredentialMessage(holderPid).build();
+
+        var token = createToken(createClaims().expirationTime(Date.from(now().minus(1, ChronoUnit.HOURS))).build());
+        var request = createCredentialMessageRequest(token, credentialMessage).build();
+
+        executeRequest(request, TestFixtures::assert4xxxCode);
+    }
+
+    @MandatoryTest
+    @DisplayName("6.5.1 CredentialService rejects an invalid auth token - iat in the future")
+    void cs_06_05_01_credentialMessage_iatInFuture(@HolderPid String holderPid) {
+        var credentialMessage = createCredentialMessage(holderPid).build();
+
+        var token = createToken(createClaims().issueTime(Date.from(now().plus(1, ChronoUnit.HOURS))).build());
+        var request = createCredentialMessageRequest(token, credentialMessage).build();
+
+        executeRequest(request, TestFixtures::assert4xxxCode);
+    }
+
+    @MandatoryTest
+    @DisplayName("6.5.1 CredentialService rejects an invalid auth token - nbf")
+    void cs_06_05_01_credentialMessage_nbfViolated(@HolderPid String holderPid) {
+        var credentialMessage = createCredentialMessage(holderPid).build();
+
+        var token = createToken(createClaims().notBeforeTime(Date.from(now().plus(1, ChronoUnit.HOURS))).build());
+        var request = createCredentialMessageRequest(token, credentialMessage).build();
+
+        executeRequest(request, TestFixtures::assert4xxxCode);
+    }
+
+    @MandatoryTest
+    @DisplayName("6.5.1 CredentialService rejects an invalid auth token - incorrect aud")
+    void cs_06_05_01_credentialMessage_incorrectAudience(@HolderPid String holderPid, @Did(THIRD_PARTY) String thirdPartyDid) {
+        var credentialMessage = createCredentialMessage(holderPid).build();
+
+        var token = createToken(createClaims().audience(thirdPartyDid).build());
+        var request = createCredentialMessageRequest(token, credentialMessage).build();
+
+        executeRequest(request, TestFixtures::assert4xxxCode);
+    }
+
+    @MandatoryTest
+    @DisplayName("6.5.1 CredentialService rejects an invalid auth token - iss != sub")
+    void cs_06_05_01_credentialMessage_issNotEqualToSub(@HolderPid String holderPid, @Did(THIRD_PARTY) String thirdPartyDid) {
+        var credentialMessage = createCredentialMessage(holderPid).build();
+
+        var token = createToken(createClaims()
+                .issuer(issuerDid)
+                .subject(thirdPartyDid)
+                .build());
+        var request = createCredentialMessageRequest(token, credentialMessage).build();
+
+        executeRequest(request, TestFixtures::assert4xxxCode);
+    }
+
+    @MandatoryTest
+    @DisplayName("6.5.1 CredentialService rejects an invalid auth token - jti used before")
+    void cs_06_05_01_credentialMessage_jtiAlreadyUsed(@HolderPid String holderPid) {
+        var credentialMessage = createCredentialMessage(holderPid).build();
+
+        var token = createToken(createClaims().build());
+        var request = createCredentialMessageRequest(token, credentialMessage).build();
+
+        executeRequest(request, response -> assertThat(response.isSuccessful()).isTrue());
+        executeRequest(request, TestFixtures::assert4xxxCode);
+    }
+
+    @MandatoryTest
+    @DisplayName("6.5.1 CredentialService rejects an invalid status string")
+    void cs_06_05_01_credentialMessage_invalidStatus(@HolderPid String holderPid) {
+        var credentialMessage = createCredentialMessage(holderPid)
+                .property("status", "INVALID_STATUS").build();
+
+        var token = createToken(createClaims().build());
+        var request = createCredentialMessageRequest(token, credentialMessage).build();
+
+        executeRequest(request, TestFixtures::assert4xxxCode);
+    }
+
+    private JWTClaimsSet.Builder createClaims() {
+        return new JWTClaimsSet.Builder()
+                .audience(holderDid)
+                .issuer(issuerDid)
+                .subject(issuerDid)
+                .jwtID(randomUUID().toString())
+                .issueTime(new Date())
+                .expirationTime(Date.from(now().plusSeconds(600)));
+    }
+
+    private String createToken(JWTClaimsSet claims) {
+        return issuerKeyService.sign(emptyMap(), claims);
+    }
+
+    /**
+     * Resolves the credential service endpoint from its DID.
+     */
+    protected String resolveCredentialServiceEndpoint() {
+        var didClient = new DidClient(false);
+        var document = didClient.resolveDocument(holderDid);
+        return document.getServiceEntry(CREDENTIAL_SERVICE_TYPE).getServiceEndpoint();
+    }
+
+    private Request.Builder createCredentialMessageRequest(String authToken, Map<String, Object> credentialMessage) {
+        var endpoint = resolveCredentialServiceEndpoint();
+        try {
+            var builder = new Request.Builder()
+                    .url(endpoint + CREDENTIALS_PATH)
+                    .post(RequestBody.create(mapper.writeValueAsString(credentialMessage), MediaType.parse("application/json")));
+            if (authToken != null) {
+                builder.addHeader(AUTHORIZATION, "Bearer " + authToken);
+            }
+            return builder;
+        } catch (JsonProcessingException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private DcpMessageBuilder createCredentialMessage(String holderPid) {
+        return DcpMessageBuilder.newInstance()
+                .type(CREDENTIAL_MESSAGE_TYPE)
+                .property("issuerPid", UUID.randomUUID().toString())
+                .property("holderPid", holderPid)
+                .property("status", "ISSUED")
+                .property("credentials", List.of(
+                        Map.of("credentialType", MEMBERSHIP_CREDENTIAL_TYPE,
+                                "format", "VC1_0_JWT",
+                                "payload", membershipCredential.rawCredential()),
+                        Map.of("credentialType", SENSITIVE_DATA_CREDENTIAL_TYPE,
+                                "format", "VC1_0_JWT",
+                                "payload", sensitiveDataCredential.rawCredential())
+                ));
+    }
+
+
+}

--- a/dcp-testcases/src/main/java/org/eclipse/dataspacetck/dcp/verification/issuance/cs/CredentialOfferTest.java
+++ b/dcp-testcases/src/main/java/org/eclipse/dataspacetck/dcp/verification/issuance/cs/CredentialOfferTest.java
@@ -12,11 +12,8 @@
  *
  */
 
-package org.eclipse.dataspacetck.dcp.system.annotation;
+package org.eclipse.dataspacetck.dcp.verification.issuance.cs;
 
-/**
- * A holder, verifier or third-party.
- */
-public enum RoleType {
-    HOLDER, ISSUER, VERIFIER, THIRD_PARTY
+public class CredentialOfferTest {
+
 }


### PR DESCRIPTION

## What this PR changes/adds

this PR adds tests for credential issuance, with the CredentialService being the System-Under-Test

## Why it does that

DCP test kit

## Further notes

run the tests by supplying `"dataspacetck.test.package=org.eclipse.dataspacetck.dcp.verification.issuance.cs"` as test package

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at
the [contributing guidelines](https://github.com/eclipse-dataspacetck/cvf/blob/main/CONTRIBUTING.md#submit-a-pull-request)
and our [etiquette for pull requests](https://github.com/eclipse-dataspacetck/cvf/blob/main/pr_etiquette.md)._
