### PR TITLE
chore: update schema with latest version for presentation query message

### DIFF
--- a/dcp-testcases/src/main/resources/common/context-schema.json
+++ b/dcp-testcases/src/main/resources/common/context-schema.json
@@ -7,7 +7,7 @@
       "$ref": "#/definitions/ContextSchema"
     }
   ],
-  "$id": "https://w3id.org/dspace-dcp/v08/common/context-schema.json",
+  "$id": "https://w3id.org/dspace-dcp/v1.0/common/context-schema.json",
   "definitions": {
     "ContextSchema": {
       "type": "array",

--- a/dcp-testcases/src/main/resources/presentation/presentation-query-message-schema.json
+++ b/dcp-testcases/src/main/resources/presentation/presentation-query-message-schema.json
@@ -19,49 +19,25 @@
           "type": "string",
           "const": "PresentationQueryMessage"
         },
-        "@type": {
-          "type": "string",
-          "const": "PresentationQueryMessage"
+        "scope": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "presentationDefinition": {
+          "type": "object",
+          "$ref": "https://identity.foundation/presentation-exchange/schemas/presentation-definition.json"
         }
       },
-      "allOf": [
-        {
-          "oneOf": [
-            {
-              "properties": {
-                "scope": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              },
-              "required": [
-                "scope"
-              ]
-            },
-            {
-              "properties": {
-                "presentationDefinition": {
-                  "type": "object",
-                  "$ref": "https://identity.foundation/presentation-exchange/schemas/presentation-definition.json"
-                }
-              },
-              "required": [
-                "presentationDefinition"
-              ]
-            }
-          ]
-        },
-        {
-          "oneOf": [
-            {"required": ["type"], "not":  {"required": ["@type"]}},
-            {"required": ["@type"], "not":  {"required":  ["type"]}}
-          ]
-        }
+      "anyOf": [
+        { "required": ["scope"] },
+        { "required": ["presentationDefinition"] }
       ],
       "required": [
-        "@context"
+        "@context",
+        "type"
       ]
     }
   }


### PR DESCRIPTION
## What this PR changes/adds

Align the schema of `PresentationQueryMessage` with the latest available in the spec

## Why it does that

the schema in this repo it  slightly different which didn't contain the latest spec changes 

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at
the [contributing guidelines](https://github.com/eclipse-dataspacetck/cvf/blob/main/CONTRIBUTING.md#submit-a-pull-request)
and our [etiquette for pull requests](https://github.com/eclipse-dataspacetck/cvf/blob/main/pr_etiquette.md)._
