### PR TITLE
fix: bump dspace uri to 2025/1 one

### DIFF
--- a/dcp-testcases/src/main/java/org/eclipse/dataspacetck/dcp/verification/presentation/verifier/AbstractVerifierPresentationFlowTest.java
+++ b/dcp-testcases/src/main/java/org/eclipse/dataspacetck/dcp/verification/presentation/verifier/AbstractVerifierPresentationFlowTest.java
@@ -61,8 +61,8 @@ public class AbstractVerifierPresentationFlowTest {
     protected static String createTriggerMessage() {
         return """
                 {
-                    "@type":  "https://w3id.org/dspace/2024/1/CatalogRequestMessage",
-                    "https://w3id.org/dspace/v0.8/filter": {}
+                    "@type": "https://w3id.org/dspace/2025/1/CatalogRequestMessage",
+                    "https://w3id.org/dspace/2025/1/filter": {}
                 }
                 """;
     }


### PR DESCRIPTION
## What this PR changes/adds

Bump the `dspace` IRI to `2025/1` version

## Why it does that

make it work with stable DSP protocol

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at
the [contributing guidelines](https://github.com/eclipse-dataspacetck/cvf/blob/main/CONTRIBUTING.md#submit-a-pull-request)
and our [etiquette for pull requests](https://github.com/eclipse-dataspacetck/cvf/blob/main/pr_etiquette.md)._
