### PR TITLE
fix: fix after shadow plugin upgrade

### DIFF
--- a/dcp-tck/build.gradle.kts
+++ b/dcp-tck/build.gradle.kts
@@ -44,6 +44,7 @@ configure<DockerExtension> {
 }
 tasks.withType<ShadowJar> {
     exclude("**/pom.properties", "**/pom.xml")
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     mergeServiceFiles()
     archiveFileName.set("${project.name}-runtime.jar") // should be something other than "dsp-tck.jar", to avoid erroneous task dependencies
 


### PR DESCRIPTION
## What this PR changes/adds

Fix tests are not run for Docker and shadow jar builds

## Why it does that

Regression after shadow plugin upgrade in `1.0.0-RC6`

## Further notes

Based on dsp-tck fix https://github.com/eclipse-dataspacetck/dsp-tck/pull/208

## Linked Issue(s)

Closes #112
