### PR TITLE
fix(credential): use profile string as format wire value

### DIFF
--- a/dcp-api/src/main/java/org/eclipse/dataspacetck/dcp/system/model/vc/CredentialFormat.java
+++ b/dcp-api/src/main/java/org/eclipse/dataspacetck/dcp/system/model/vc/CredentialFormat.java
@@ -18,5 +18,12 @@ package org.eclipse.dataspacetck.dcp.system.model.vc;
  * Verifable credential formats.
  */
 public enum CredentialFormat {
-    VC1_0_JWT, VC2_0_JOSE
+    VC1_0_JWT("vc11-sl2021/jwt"),
+    VC2_0_JOSE("vc20-bssl/jwt");
+
+    public final String profileString;
+
+    CredentialFormat(String profileString) {
+        this.profileString = profileString;
+    }
 }

--- a/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/assembly/ServiceAssembly.java
+++ b/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/assembly/ServiceAssembly.java
@@ -225,12 +225,12 @@ public class ServiceAssembly {
                 .property("credentials", List.of(
                         Map.of(
                                 "credentialType", MEMBERSHIP_CREDENTIAL_TYPE,
-                                "format", "VC1_0_JWT",
+                                "format", VC1_0_JWT.profileString,
                                 "payload", membershipContainer.rawCredential()
                         ),
                         Map.of(
                                 "credentialType", SENSITIVE_DATA_CREDENTIAL_TYPE,
-                                "format", "VC1_0_JWT",
+                                "format", VC1_0_JWT.profileString,
                                 "payload", sensitiveDataContainer.rawCredential()
                         )))
                 .property("status", "ISSUED");

--- a/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/cs/CredentialServiceImpl.java
+++ b/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/cs/CredentialServiceImpl.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -147,7 +148,11 @@ public class CredentialServiceImpl implements CredentialService {
         }
         message.getCredentials()
                 .forEach(cred -> {
-                    var container = new VcContainer(cred.payload(), createCredential(cred), CredentialFormat.valueOf(cred.format()));
+                    var format = Arrays.stream(CredentialFormat.values())
+                            .filter(f -> f.profileString.equals(cred.format()))
+                            .findFirst()
+                            .orElseThrow(() -> new IllegalArgumentException("Unknown format: " + cred.format()));
+                    var container = new VcContainer(cred.payload(), createCredential(cred), format);
                     credentialsByType.computeIfAbsent(cred.credentialType(), k -> new ArrayList<>()).add(container);
                 });
         return success();

--- a/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/issuer/IssuerServiceImpl.java
+++ b/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/issuer/IssuerServiceImpl.java
@@ -100,7 +100,7 @@ public class IssuerServiceImpl implements IssuerService {
                         throw new IllegalArgumentException("No CredentialObject found for id: " + cred.id());
                     }
                     var format = supportedCredentialFormats.get(descriptor.getProfile());
-                    return new CredentialMessage.CredentialContainer(descriptor.getCredentialType(), generateJwtCredential(descriptor.getCredentialType(), gen, holderDid, issuerDid).getContent(), format.name());
+                    return new CredentialMessage.CredentialContainer(descriptor.getCredentialType(), generateJwtCredential(descriptor.getCredentialType(), gen, holderDid, issuerDid).getContent(), format.profileString);
                 }).toList();
         var issuerPid = randomUUID().toString();
         var credentialsMessage = CredentialMessage.Builder.newInstance()

--- a/dcp-testcases/src/main/java/org/eclipse/dataspacetck/dcp/verification/issuance/cs/CredentialIssuanceTest.java
+++ b/dcp-testcases/src/main/java/org/eclipse/dataspacetck/dcp/verification/issuance/cs/CredentialIssuanceTest.java
@@ -47,6 +47,7 @@ import static org.eclipse.dataspacetck.dcp.system.annotation.RoleType.THIRD_PART
 import static org.eclipse.dataspacetck.dcp.system.message.DcpConstants.AUTHORIZATION;
 import static org.eclipse.dataspacetck.dcp.system.message.DcpConstants.CREDENTIALS_PATH;
 import static org.eclipse.dataspacetck.dcp.system.message.DcpConstants.CREDENTIAL_MESSAGE_TYPE;
+import static org.eclipse.dataspacetck.dcp.system.model.vc.CredentialFormat.VC1_0_JWT;
 import static org.eclipse.dataspacetck.dcp.system.profile.TestProfile.MEMBERSHIP_CREDENTIAL_TYPE;
 import static org.eclipse.dataspacetck.dcp.system.profile.TestProfile.SENSITIVE_DATA_CREDENTIAL_TYPE;
 import static org.eclipse.dataspacetck.dcp.verification.fixtures.TestFixtures.executeRequest;
@@ -233,10 +234,10 @@ public class CredentialIssuanceTest extends AbstractCredentialIssuanceTest {
                 .property("status", "ISSUED")
                 .property("credentials", List.of(
                         Map.of("credentialType", MEMBERSHIP_CREDENTIAL_TYPE,
-                                "format", "VC1_0_JWT",
+                                "format", VC1_0_JWT.profileString,
                                 "payload", membershipCredential.rawCredential()),
                         Map.of("credentialType", SENSITIVE_DATA_CREDENTIAL_TYPE,
-                                "format", "VC1_0_JWT",
+                                "format", VC1_0_JWT.profileString,
                                 "payload", sensitiveDataCredential.rawCredential())
                 ));
     }


### PR DESCRIPTION
Closes #138

`CredentialFormat` enum values now carry a `profileString` field (`vc11-sl2021/jwt`, `vc20-bssl/jwt`). All credential format serialization/deserialization updated to use these profile strings instead of enum names.