### PR TITLE
feat(did): add capabilityInvocation, authentication and assertionMethod key relations

### DIFF
--- a/dcp-api/src/main/java/org/eclipse/dataspacetck/dcp/system/model/did/DidDocument.java
+++ b/dcp-api/src/main/java/org/eclipse/dataspacetck/dcp/system/model/did/DidDocument.java
@@ -39,6 +39,15 @@ public class DidDocument extends ExtensibleModel {
     @JsonProperty("verificationMethod")
     private List<VerificationMethod> verificationMethods = new ArrayList<>();
 
+    @JsonProperty("authentication")
+    private List<String> authentication = new ArrayList<>();
+
+    @JsonProperty("assertionMethod")
+    private List<String> assertionMethod = new ArrayList<>();
+
+    @JsonProperty("capabilityInvocation")
+    private List<String> capabilityInvocation = new ArrayList<>();
+
     private DidDocument() {
     }
 
@@ -52,6 +61,18 @@ public class DidDocument extends ExtensibleModel {
 
     public List<VerificationMethod> getVerificationMethods() {
         return verificationMethods;
+    }
+
+    public List<String> getAuthentication() {
+        return authentication;
+    }
+
+    public List<String> getAssertionMethod() {
+        return assertionMethod;
+    }
+
+    public List<String> getCapabilityInvocation() {
+        return capabilityInvocation;
     }
 
     public ServiceEntry getServiceEntry(String type) {
@@ -96,6 +117,21 @@ public class DidDocument extends ExtensibleModel {
 
         public Builder verificationMethod(List<VerificationMethod> methods) {
             document.verificationMethods.addAll(methods);
+            return this;
+        }
+
+        public Builder authentication(List<String> refs) {
+            document.authentication.addAll(refs);
+            return this;
+        }
+
+        public Builder assertionMethod(List<String> refs) {
+            document.assertionMethod.addAll(refs);
+            return this;
+        }
+
+        public Builder capabilityInvocation(List<String> refs) {
+            document.capabilityInvocation.addAll(refs);
             return this;
         }
 

--- a/dcp-api/src/test/java/org/eclipse/dataspacetck/dcp/system/model/did/DidDocumentTest.java
+++ b/dcp-api/src/test/java/org/eclipse/dataspacetck/dcp/system/model/did/DidDocumentTest.java
@@ -42,7 +42,10 @@ class DidDocumentTest {
                     "x" : "izxXHDdzCpmt_Ivvn19qOZVhLDE29ViWPJENBJeEncA",
                     "y" : "dbn4rBSbYFbyUSbt0GzfKpxK4eODNRkWaI5LB36P9MY"
                   }
-                } ]
+                } ],
+                "authentication" : [ "43cecd95-7a59-4a5f-b2d0-0ec73ae41a0c" ],
+                "assertionMethod" : [ "43cecd95-7a59-4a5f-b2d0-0ec73ae41a0c" ],
+                "capabilityInvocation" : [ "43cecd95-7a59-4a5f-b2d0-0ec73ae41a0c" ]
              }""";
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -56,6 +59,9 @@ class DidDocumentTest {
         assertThat(deserialized.getVerificationMethods()).allMatch(v -> v.getId().equals("43cecd95-7a59-4a5f-b2d0-0ec73ae41a0c"));
         assertThat(deserialized.getVerificationMethod("43cecd95-7a59-4a5f-b2d0-0ec73ae41a0c")).isNotNull();
         assertThat(deserialized.getVerificationMethod("43cecd95-7a59-4a5f-b2d0-0ec73ae41a0c").succeeded()).isTrue();
+        assertThat(deserialized.getAuthentication()).containsExactly("43cecd95-7a59-4a5f-b2d0-0ec73ae41a0c");
+        assertThat(deserialized.getAssertionMethod()).containsExactly("43cecd95-7a59-4a5f-b2d0-0ec73ae41a0c");
+        assertThat(deserialized.getCapabilityInvocation()).containsExactly("43cecd95-7a59-4a5f-b2d0-0ec73ae41a0c");
         assertThat(deserialized.getServiceEntry("CredentialService")).isNotNull();
     }
 }

--- a/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/did/DidServiceImpl.java
+++ b/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/did/DidServiceImpl.java
@@ -48,16 +48,20 @@ public class DidServiceImpl implements DidService {
     }
 
     protected DidDocument.Builder createDocumentBuilder() {
+        var vmId = did + "#" + keyService.getPublicKey().getKeyID();
         return DidDocument.Builder.newInstance()
                 .id(did)
                 .context(List.of(DID_CONTEXT, DCP_NAMESPACE))
                 .service(List.of(new ServiceEntry("TCK-Credential-Service", CREDENTIAL_SERVICE_TYPE, baseEndpoint)))
                 .verificationMethod(List.of(VerificationMethod.Builder.newInstance()
-                        .id(did + "#" + keyService.getPublicKey().getKeyID())
+                        .id(vmId)
                         .type("JsonWebKey2020") // FIXME
                         .controller(did)
                         .publicKeyJwk(keyService.getPublicKey().toJSONObject())
-                        .build()));
+                        .build()))
+                .authentication(List.of(vmId))
+                .assertionMethod(List.of(vmId))
+                .capabilityInvocation(List.of(vmId));
     }
 
 }


### PR DESCRIPTION
- Added `authentication`, `assertionMethod`, and `capabilityInvocation` fields to `DidDocument` as `List<String>` 
- `DidServiceImpl.createDocumentBuilder()` now populates all three fields with the same id
- `DidDocumentTest` updated 

Closes #145
