### PR TITLE
refactor: use common core and runtime libraries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,15 +8,4 @@
 # Each line is a file pattern followed by one or more contact persons. The last matching pattern has the most precedence.
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
-CONTRIBUTING.md @jimmarino @wolf4ood @paullatzelsperger
-LICENSE @jimmarino @wolf4ood @paullatzelsperger
-NOTICE.md @jimmarino @wolf4ood @paullatzelsperger
-
-.github/actions/ @paullatzelsperger
-.github/ISSUE_TEMPLATE @paullatzelsperger
-.github/workflows/ @paullatzelsperger
-
-/core/ @jimmarino @paullatzelsperger @wolf4ood
-/gradle/ @wolf4ood @paullatzelsperger
-/dsp/ @jimmarino
-/runtimes/ @jimmarino @wolf4ood @paullatzelsperger
+* @eclipse-dataspacetck/technology-dataspacetck-committers

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,6 @@ buildscript {
     }
 }
 
-
 allprojects {
 
     apply(plugin = "java-library")

--- a/dcp-api/build.gradle.kts
+++ b/dcp-api/build.gradle.kts
@@ -15,5 +15,5 @@
 
 dependencies {
     implementation(rootProject.libs.nimbus.jwt)
-    implementation(rootProject.libs.tck.dsp.core)
+    implementation(rootProject.libs.tck.core)
 }

--- a/dcp-system/build.gradle.kts
+++ b/dcp-system/build.gradle.kts
@@ -14,7 +14,7 @@
  */
 
 dependencies {
-    implementation(rootProject.libs.tck.dsp.core)
+    implementation(rootProject.libs.tck.core)
     implementation(rootProject.libs.nimbus.jwt)
     implementation(rootProject.libs.bouncyCastle.bcprovJdk18on)
     implementation(rootProject.libs.schema.validator) {

--- a/dcp-tck/build.gradle.kts
+++ b/dcp-tck/build.gradle.kts
@@ -29,8 +29,8 @@ plugins {
 }
 
 dependencies {
-    implementation(rootProject.libs.tck.dsp.core)
-    implementation(rootProject.libs.tck.dsp.tck.runtime)
+    implementation(rootProject.libs.tck.core)
+    implementation(rootProject.libs.tck.runtime)
     implementation(libs.junit.platform.launcher)
 
     implementation(project(":dcp-api"))

--- a/dcp-testcases/build.gradle.kts
+++ b/dcp-testcases/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
 }
 
 dependencies {
-    implementation(rootProject.libs.tck.dsp.core)
+    implementation(rootProject.libs.tck.core)
     implementation(rootProject.libs.okhttp)
     implementation(rootProject.libs.nimbus.jwt)
     implementation(rootProject.libs.assertj)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,11 +22,10 @@ titanium = "1.7.0"
 
 # modules from tck-common
 tck-common-api = { module = "org.eclipse.dataspacetck.common:core-api", version.ref = "tck" }
-tck-dsp-core = { module = "org.eclipse.dataspacetck.dsp:core", version.ref = "tck" }
-tck-dsp-tck-runtime = { module = "org.eclipse.dataspacetck.dsp:tck-runtime", version.ref = "tck" }
+tck-core = { module = "org.eclipse.dataspacetck.common:core", version.ref = "tck" }
+tck-runtime = { module = "org.eclipse.dataspacetck.common:tck-runtime", version.ref = "tck" }
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
-bouncyCastle-bcpkixJdk18on = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncyCastle-jdk18on" }
 bouncyCastle-bcprovJdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncyCastle-jdk18on" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 jackson-jsonp = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jakarta-jsonp", version.ref = "jackson" }

--- a/pr_etiquette.md
+++ b/pr_etiquette.md
@@ -77,7 +77,7 @@ Submitting pull requests should be done while adhering to a couple of simple rul
 - Please complete reviews within two business days or delegate to another committer, removing yourself as a reviewer.
 - If you have been requested as reviewer, but cannot do the review for any reason (time, lack of knowledge in particular
   area, etc.) please comment that in the PR and remove yourself as a reviewer, suggesting a stand-in. The [code
-  owners document](CODEOWNERS) should help with that.
+  owners document](.github/CODEOWNERS) should help with that.
 - Don't be overly pedantic.
 - Don't argue basic principles (code style, architectural decisions, etc.)
 - Use the `suggestion` feature of GitHub for small/simple changes.


### PR DESCRIPTION
## What this PR changes/adds

Use `core` and `tck-runtime` from `common` repository

## Why it does that

_Briefly state why the change was necessary._

## Further notes
- used better codeowners file

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at
the [contributing guidelines](https://github.com/eclipse-dataspacetck/cvf/blob/main/CONTRIBUTING.md#submit-a-pull-request)
and our [etiquette for pull requests](https://github.com/eclipse-dataspacetck/cvf/blob/main/pr_etiquette.md)._
