### PR TITLE
fix: align TCK with DCP specification change

### DIFF
--- a/dcp-testcases/src/main/java/org/eclipse/dataspacetck/dcp/verification/presentation/cs/PresentationFlowSection5Test.java
+++ b/dcp-testcases/src/main/java/org/eclipse/dataspacetck/dcp/verification/presentation/cs/PresentationFlowSection5Test.java
@@ -204,7 +204,7 @@ public class PresentationFlowSection5Test extends AbstractPresentationFlowTest {
                 .build();
 
         var request = createPresentationRequest(authToken, message);
-        executeRequest(request, TestFixtures::assert4xxCode);
+        executeRequest(request, response -> verifyCredentials(response, MEMBERSHIP_CREDENTIAL_TYPE));
     }
 
 }


### PR DESCRIPTION
## What this PR changes/adds

> If the array contains scopes that a client is not entitled to, the Credential Service MUST return HTTP 2xx with the PresentationResponseMessage's presentation array holding less entries than requested. 

so the scope escalation test must be changed to expect a 200, and specifically, only the MembershipCredential

## Why it does that

align TCK with spec

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Relates to https://github.com/eclipse-edc/IdentityHub/pull/992

_Please be sure to take a look at
the [contributing guidelines](https://github.com/eclipse-dataspacetck/cvf/blob/main/CONTRIBUTING.md#submit-a-pull-request)
and our [etiquette for pull requests](https://github.com/eclipse-dataspacetck/cvf/blob/main/pr_etiquette.md)._
