### PR TITLE
fix(vc): use credentialSubject id as JWT sub claim

### DIFF
--- a/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/generation/JwtCredentialGenerator.java
+++ b/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/generation/JwtCredentialGenerator.java
@@ -51,9 +51,13 @@ public class JwtCredentialGenerator implements CredentialGenerator {
         if (!issuerDid.equals(credential.getIssuer())) {
             throw new RuntimeException(format("Credential issuer '%s' not equal to issuer DID: %s", credential.getIssuer(), issuerDid));
         }
+        var credentialSubjectId = (String) credential.getCredentialSubject().get("id");
+        if (credentialSubjectId == null) {
+            throw new RuntimeException("credentialSubject must contain an 'id' property");
+        }
         var claims = new JWTClaimsSet.Builder()
                 .issuer(issuerDid)
-                .subject(credential.getId())
+                .subject(credentialSubjectId)
                 .claim("jti", randomUUID())
                 .notBeforeTime(now)
                 .issueTime(now)

--- a/dcp-system/src/test/java/org/eclipse/dataspacetck/dcp/system/generation/JwtCredentialGeneratorTest.java
+++ b/dcp-system/src/test/java/org/eclipse/dataspacetck/dcp/system/generation/JwtCredentialGeneratorTest.java
@@ -29,10 +29,13 @@ import java.util.Map;
 import static java.time.Instant.now;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.dataspacetck.dcp.system.crypto.Keys.createVerifier;
 
 class JwtCredentialGeneratorTest {
     private static final String ISSUER_DID = "did:web:localhost%3A8083:issuer";
+
+    private static final String SUBJECT_DID = "did:web:localhost%3A8083:subject";
 
     private JwtCredentialGenerator generator;
     private KeyServiceImpl keyService;
@@ -40,7 +43,7 @@ class JwtCredentialGeneratorTest {
     @Test
     void verifyGeneration() throws ParseException, JOSEException {
         var credential = VerifiableCredential.Builder.newInstance()
-                .credentialSubject(Map.of("memberLevel", "gold"))
+                .credentialSubject(Map.of("id", SUBJECT_DID, "memberLevel", "gold"))
                 .id(randomUUID().toString())
                 .issuanceDate(now().toString())
                 .expirationDate(now().plusSeconds(600).toString())
@@ -55,9 +58,27 @@ class JwtCredentialGeneratorTest {
 
         assertThat(parsed.getHeader().getKeyID()).isEqualTo(ISSUER_DID + "#" + keyService.getPublicKey().getKeyID());
         assertThat(claims).extracting(c -> c.get("vc")).hasFieldOrProperty("credentialSubject");
+        assertThat(parsed.getJWTClaimsSet().getSubject()).isEqualTo(SUBJECT_DID);
 
         var verifier = createVerifier(keyService.getPublicKey().toECKey().toECPublicKey());
         assertThat(parsed.verify(verifier)).isTrue();
+    }
+
+    @Test
+    void verifyGeneration_noSubjectId_throwsException() {
+        var credential = VerifiableCredential.Builder.newInstance()
+                .credentialSubject(Map.of("memberLevel", "gold"))
+                .id(randomUUID().toString())
+                .issuanceDate(now().toString())
+                .expirationDate(now().plusSeconds(600).toString())
+                .issuer(ISSUER_DID)
+                .type(List.of("VerifiableCredential"))
+                .context(List.of("https://www.w3.org/2018/credentials/v1"))
+                .build();
+
+        assertThatThrownBy(() -> generator.generateCredential(credential))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("credentialSubject must contain an 'id' property");
     }
 
     @BeforeEach


### PR DESCRIPTION
Closes #156

The JWT envelope was using the credential's `id` as the `sub` claim. Per the [W3C VC Data Model](https://www.w3.org/TR/2022/REC-vc-data-model-20220303/#jwt-encoding), `sub` must be the `credentialSubject`'s `id`.

Throws an explicit `RuntimeException` if `credentialSubject` has no `id` property.