### PR TITLE
fix: remove requestId and use singular profile in CredentialObject

### DIFF
--- a/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/assembly/ServiceAssembly.java
+++ b/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/assembly/ServiceAssembly.java
@@ -219,7 +219,6 @@ public class ServiceAssembly {
     private void sendCredentialMessage(BaseAssembly baseAssembly, String correlation, VcContainer membershipContainer, VcContainer sensitiveDataContainer, String token) throws JsonProcessingException {
         var credentialsObject = DcpMessageBuilder.newInstance()
                 .type(CREDENTIAL_MESSAGE_TYPE)
-                .property("requestId", correlation)
                 .property("issuerPid", UUID.randomUUID().toString())
                 .property("holderPid", correlation)
                 .property("credentials", List.of(

--- a/dcp-testcases/src/main/java/org/eclipse/dataspacetck/dcp/verification/issuance/cs/CredentialOfferTest.java
+++ b/dcp-testcases/src/main/java/org/eclipse/dataspacetck/dcp/verification/issuance/cs/CredentialOfferTest.java
@@ -233,7 +233,7 @@ public class CredentialOfferTest extends AbstractCredentialIssuanceTest {
                                 "credentialType", "MembershipCredential",
                                 "offerReason", "reissue",
                                 "bindingMethods", List.of("did:web:"),
-                                "profiles", List.of("vc11-sl2021/jwt", "vc20-bssl/jwt"),
+                                "profile", "vc11-sl2021/jwt",
                                 "issuancePolicy", Map.of()) //fixme: add issuance policy
                 ));
     }


### PR DESCRIPTION
Fixes two small spec-conformance bugs.

- Closes #155: remove the `requestId` property from the `CredentialMessage` payload built in `ServiceAssembly.sendCredentialMessage` — it isn't part of the spec.
- Closes #161: `CredentialObject.profile` is a singular string per the spec; the `CredentialOfferTest` payload was sending `"profiles"` as a list. Changed to a single `"profile"` string.