### PR TITLE
build: expose all the required deps in dcp-tck

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,10 +288,7 @@ void runVppTests() {
 
 The following Maven dependencies are required:
 
-- `org.eclipse.dataspacetck.dcp:dcp-testcases:<VERSION>`: for the test cases
-- `org.eclipse.dataspacetck.dsp:tck-runtime:<VERSION>`: to launch the TCK from JUnit
-- `org.eclipse.dataspacetck.dsp:core:<VERSION>`: for the ConsoleMonitor
-- `org.eclipse.dataspacetck.dcp:dcp-system:<VERSION>`: for the launcher that runs the TCK test cases
+- `org.eclipse.dataspacetck.dcp:dcp-tck:<VERSION>`: brings in all the TCK dependencies needed to run the tests
 - `org.junit.platform:junit-platform-launcher:<JUNIT_VERSION>`
 
 ### 3.3 Using the command line

--- a/dcp-tck/build.gradle.kts
+++ b/dcp-tck/build.gradle.kts
@@ -29,13 +29,14 @@ plugins {
 }
 
 dependencies {
-    implementation(rootProject.libs.tck.core)
-    implementation(rootProject.libs.tck.runtime)
+    api(rootProject.libs.tck.core)
+    api(rootProject.libs.tck.runtime)
+
     implementation(libs.junit.platform.launcher)
 
-    implementation(project(":dcp-api"))
-    implementation(project(":dcp-system"))
-    implementation(project(":dcp-testcases"))
+    api(project(":dcp-api"))
+    api(project(":dcp-system"))
+    api(project(":dcp-testcases"))
 }
 
 
@@ -47,7 +48,6 @@ tasks.withType<ShadowJar> {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
     mergeServiceFiles()
     archiveFileName.set("${project.name}-runtime.jar") // should be something other than "dsp-tck.jar", to avoid erroneous task dependencies
-
 }
 
 application {


### PR DESCRIPTION
## What this PR changes/adds

set tck related dependencies as `api`, so `dcp-tck` will become the only dependency that needs to be declared in order to being able to run the TCK harness

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #168

_Please be sure to take a look at
the [contributing guidelines](https://github.com/eclipse-dataspacetck/cvf/blob/main/CONTRIBUTING.md#submit-a-pull-request)
and our [etiquette for pull requests](https://github.com/eclipse-dataspacetck/cvf/blob/main/pr_etiquette.md)._
