### PR TITLE
fix: use URI credential identifiers

### DIFF
--- a/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/assembly/ServiceAssembly.java
+++ b/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/assembly/ServiceAssembly.java
@@ -298,7 +298,7 @@ public class ServiceAssembly {
     private VerifiableCredential createCredential(String issuerDid, String holderDid, List<String> additionalContext, String credentialType, Map<String, Object> subjectProperties) {
         var context = Stream.concat(Stream.of(CredentialConstants.CONTEXT_V1), additionalContext.stream()).distinct().toList();
         return VerifiableCredential.Builder.newInstance()
-                .id(randomUUID().toString())
+                .id("urn:uuid:" + randomUUID())
                 .issuanceDate(Instant.now().toString())
                 .expirationDate(Instant.now().plusSeconds(600).toString())
                 .issuer(issuerDid)

--- a/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/issuer/IssuerServiceImpl.java
+++ b/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/issuer/IssuerServiceImpl.java
@@ -137,7 +137,7 @@ public class IssuerServiceImpl implements IssuerService {
     private Result<String> generateJwtCredential(String type, JwtCredentialGenerator gen, String holderDid, String issuerDid) {
         return gen.generateCredential(VerifiableCredential.Builder.newInstance()
                 .credentialSubject(Map.of("id", holderDid))
-                .id(randomUUID().toString())
+                .id("urn:uuid:" + randomUUID())
                 .issuanceDate(now().toString())
                 .expirationDate(now().plusSeconds(600).toString())
                 .issuer(issuerDid)

--- a/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/revocation/BitstringStatusListService.java
+++ b/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/revocation/BitstringStatusListService.java
@@ -26,7 +26,7 @@ public class BitstringStatusListService implements CredentialRevocationService {
     public static final String REVOCATION = "revocation";
     private static final int LENGTH = 16 * 1024; // 16k bits
     private final BitString bitstring = BitString.Builder.newInstance().size(LENGTH).build();
-    private final String credentialId = UUID.randomUUID().toString();
+    private final String credentialId = "urn:uuid:" + UUID.randomUUID();
     private final String issuerDid;
     private final String address;
 

--- a/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/revocation/StatusList2021Service.java
+++ b/dcp-system/src/main/java/org/eclipse/dataspacetck/dcp/system/revocation/StatusList2021Service.java
@@ -26,7 +26,7 @@ public class StatusList2021Service implements CredentialRevocationService {
     public static final String REVOCATION = "revocation";
     private static final int LENGTH = 16 * 1024; // 16k bits
     private final BitString bitstring = BitString.Builder.newInstance().size(LENGTH).build();
-    private final String credentialId = UUID.randomUUID().toString();
+    private final String credentialId = "urn:uuid:" + UUID.randomUUID();
     private final String issuerDid;
     private final String address;
 

--- a/dcp-system/src/test/java/org/eclipse/dataspacetck/dcp/system/cs/CredentialServiceImplTest.java
+++ b/dcp-system/src/test/java/org/eclipse/dataspacetck/dcp/system/cs/CredentialServiceImplTest.java
@@ -133,7 +133,7 @@ class CredentialServiceImplTest {
 
     private void seedMembershipCredential(CredentialServiceImpl service) {
         var credential = VerifiableCredential.Builder.newInstance()
-                .id(randomUUID().toString())
+                .id("urn:uuid:" + randomUUID())
                 .issuanceDate(now().toString())
                 .expirationDate(now().plusSeconds(600).toString())
                 .issuer(ISSUER_DID)

--- a/dcp-system/src/test/java/org/eclipse/dataspacetck/dcp/system/generation/JwtCredentialGeneratorTest.java
+++ b/dcp-system/src/test/java/org/eclipse/dataspacetck/dcp/system/generation/JwtCredentialGeneratorTest.java
@@ -44,7 +44,7 @@ class JwtCredentialGeneratorTest {
     void verifyGeneration() throws ParseException, JOSEException {
         var credential = VerifiableCredential.Builder.newInstance()
                 .credentialSubject(Map.of("id", SUBJECT_DID, "memberLevel", "gold"))
-                .id(randomUUID().toString())
+                .id("urn:uuid:" + randomUUID())
                 .issuanceDate(now().toString())
                 .expirationDate(now().plusSeconds(600).toString())
                 .issuer(ISSUER_DID)
@@ -68,7 +68,7 @@ class JwtCredentialGeneratorTest {
     void verifyGeneration_noSubjectId_throwsException() {
         var credential = VerifiableCredential.Builder.newInstance()
                 .credentialSubject(Map.of("memberLevel", "gold"))
-                .id(randomUUID().toString())
+                .id("urn:uuid:" + randomUUID())
                 .issuanceDate(now().toString())
                 .expirationDate(now().plusSeconds(600).toString())
                 .issuer(ISSUER_DID)

--- a/dcp-system/src/test/java/org/eclipse/dataspacetck/dcp/system/generation/JwtPresentationGeneratorTest.java
+++ b/dcp-system/src/test/java/org/eclipse/dataspacetck/dcp/system/generation/JwtPresentationGeneratorTest.java
@@ -57,7 +57,7 @@ class JwtPresentationGeneratorTest {
 
     @Test
     void verifyGeneration() throws ParseException, JOSEException {
-        var credential = VerifiableCredential.Builder.newInstance().id(randomUUID().toString()).build();
+        var credential = VerifiableCredential.Builder.newInstance().id("urn:uuid:" + randomUUID()).build();
         var container = new VcContainer("SampleType", SAMPLE_VC, credential, VC1_0_JWT);
         var jwt = generator.generatePresentation(VERIFIER_DID, HOLDER_DID, List.of(container));
         var parsed = SignedJWT.parse(jwt.getContent());

--- a/dcp-testcases/src/main/java/org/eclipse/dataspacetck/dcp/verification/presentation/verifier/PresentationFlowSection5Test.java
+++ b/dcp-testcases/src/main/java/org/eclipse/dataspacetck/dcp/verification/presentation/verifier/PresentationFlowSection5Test.java
@@ -255,7 +255,7 @@ public class PresentationFlowSection5Test extends AbstractVerifierPresentationFl
 
         VerifiableCredential.Builder createCredential() {
             return VerifiableCredential.Builder.newInstance()
-                    .id(randomUUID().toString())
+                    .id("urn:uuid:" + randomUUID())
                     .issuanceDate(Instant.now().toString())
                     .issuer(issuerDid)
                     .type(List.of(MEMBERSHIP_CREDENTIAL_TYPE))


### PR DESCRIPTION
## What this PR changes/adds

Adds `urn:uuid:` prefixes to credential identifiers.

## Why it does that

To be aligned with the VC Data Model specifications

## Linked Issue(s)

Closes #184 